### PR TITLE
Allow skipping unique or foreign key checks when sanitising a table

### DIFF
--- a/lib/db_sanitiser/dsl.rb
+++ b/lib/db_sanitiser/dsl.rb
@@ -36,11 +36,19 @@ module DbSanitiser
       def _run(strategy)
         instance_eval(&@block)
 
-        strategy.sanitise_table(@table_name, @columns_to_sanitise, @where_query, @columns_to_allow)
+        strategy.sanitise_table(@table_name, @columns_to_sanitise, @where_query, @columns_to_allow, @skip_unique_key_checks, @skip_foreign_key_checks)
       end
 
       def string(value)
         "\"#{value}\""
+      end
+
+      def skip_unique_key_checks
+        @skip_unique_key_checks = true
+      end
+
+      def skip_foreign_key_checks
+        @skip_foreign_key_checks = true
       end
 
       def sanitise(name, sanitised_value)

--- a/lib/db_sanitiser/strategies/dry_run_strategy.rb
+++ b/lib/db_sanitiser/strategies/dry_run_strategy.rb
@@ -5,13 +5,16 @@ module DbSanitiser
         @io = io
       end
 
-      def sanitise_table(table_name, columns_to_sanitise, where_query, allowed_columns)
+      def sanitise_table(table_name, columns_to_sanitise, where_query, allowed_columns, skip_unique_key_checks, skip_foreign_key_checks)
         update_values = columns_to_sanitise.to_a.map do |(key, value)|
           "`#{key}` = #{value}"
         end
         scope = active_record_class(table_name).all
         scope = scope.where(where_query) if where_query
+        @io.puts("Disable unique key checks") if skip_unique_key_checks
+        @io.puts("Disable foreign key checks") if skip_foreign_key_checks
         @io.puts("Sanitise rows that match: #{scope.to_sql}: #{update_values.join(', ')}")
+        @io.puts("Re-enable key checks") if skip_unique_key_checks || skip_foreign_key_checks
       end
 
       def delete_all(table_name)

--- a/lib/db_sanitiser/strategies/validate_strategy.rb
+++ b/lib/db_sanitiser/strategies/validate_strategy.rb
@@ -3,7 +3,7 @@ module DbSanitiser
     class ValidateStrategy
       ACTIVERECORD_META_TABLES = %w(schema_migrations ar_internal_metadata)
 
-      def sanitise_table(table_name, columns_to_sanitise, where_query, allowed_columns)
+      def sanitise_table(table_name, columns_to_sanitise, where_query, allowed_columns, skip_unique_key_checks, skip_foreign_key_checks)
         ar_class = active_record_class(table_name)
         columns = columns_to_sanitise.keys + allowed_columns
 


### PR DESCRIPTION
Some of our tables take a very long time to sanitise; two tables in particular take around 4hr each every night, specifically these:

```ruby
# config/db_sanitiser.rb
sanitise_table 'email_preferences' do
  sanitise 'unsubscribe_token', string("")

  allow 'id', 'user_id', 'category'
end

sanitise_table 'enrolments' do
  sanitise 'email_unenrol_token', string("dummy-unenrol-token")

  allow 'id', 'run_id', 'learner_id', 'created_at', 'updated_at', 'active', 'deactivated_at', 'fully_participated_at', 'fully_completed_at', 'first_step_completed_at'
end
```

This appears to be primarily due to unique key constraints on those tables. For every row we update, regardless of whether we update the specific columns involved in the key, the constraint is revalidated, causing a huge amount of disk I/O (since both tables are pretty large, at 35m and 22m rows respectively). Disabling unique checks on the `email_preferences` table caused the update to run in minutes on the current staging DB.

This change therefore adds two table-level options to allow skipping unique and foreign key checks:

```ruby
sanitise_table :email_preferences do
  skip_unique_key_checks
  skip_foreign_key_checks

  sanitise 'unsubscribe_token', string("")

  allow 'id', 'user_id', 'category'
end
```

These currently only work with the MySQL AR adapter. While there appears to be a SQLite equivalent for [turning off foreign keys](https://www.sqlite.org/pragma.html#pragma_foreign_keys), there doesn't appear to be one for unique keys. I've therefore shortcut the methods unless the mysql2 adapter is detected.

### Feedback

Any and all reckons are welcome, but specific questions I have are:

1. While skipping the unique checks for the above examples is safe given the current schema, the addition of new indexes could make skipping them unsafe in future. Does this seem like a reasonable risk to run?
2. This change is under-tested; while I've run it successfully against my dev DB, SQLite doesn't support the things we'd need to test it here, and I wasn't keen on the cost of switching to MySQL tests just for this change. Does that sound legit?
3. We don't actually have a use case for the foreign key skip at the moment, but I've added it cos I think we'll almost certainly find slow tables where this will help. Is that all right?