### PR TITLE
`drop_and_create_index` requires only index name

### DIFF
--- a/lib/db_sanitiser/dsl.rb
+++ b/lib/db_sanitiser/dsl.rb
@@ -58,8 +58,8 @@ module DbSanitiser
         @skip_foreign_key_checks = true
       end
 
-      def drop_and_create_index(name, columns, options={})
-        @indexes_to_drop_and_create << [name, columns, options]
+      def drop_and_create_index(name)
+        @indexes_to_drop_and_create << name
       end
 
       def sanitise(name, sanitised_value)

--- a/lib/db_sanitiser/strategies/dry_run_strategy.rb
+++ b/lib/db_sanitiser/strategies/dry_run_strategy.rb
@@ -13,9 +13,9 @@ module DbSanitiser
         scope = scope.where(where_query) if where_query
         @io.puts("Disable unique key checks") if skip_unique_key_checks
         @io.puts("Disable foreign key checks") if skip_foreign_key_checks
-        @io.puts("Drop indexes: #{indexes_to_drop_and_create.map(&:first).join(", ")}") if indexes_to_drop_and_create.any?
+        @io.puts("Drop indexes: #{indexes_to_drop_and_create.join(", ")}") if indexes_to_drop_and_create.any?
         @io.puts("Sanitise rows that match: #{scope.to_sql}: #{update_values.join(', ')}")
-        @io.puts("Create indexes: #{indexes_to_drop_and_create.map(&:first).join(", ")}") if indexes_to_drop_and_create.any?
+        @io.puts("Create indexes: #{indexes_to_drop_and_create.join(", ")}") if indexes_to_drop_and_create.any?
         @io.puts("Re-enable key checks") if skip_unique_key_checks || skip_foreign_key_checks
       end
 

--- a/lib/db_sanitiser/strategies/validate_strategy.rb
+++ b/lib/db_sanitiser/strategies/validate_strategy.rb
@@ -50,8 +50,8 @@ module DbSanitiser
       end
 
       def validate_indexes_exist(table_name, indexes_to_drop_and_create)
-        indexes_to_drop_and_create.each do |index_name, columns, options|
-          unless ActiveRecord::Base.connection.index_exists?(table_name, columns, options.merge(name: index_name))
+        indexes_to_drop_and_create.each do |index_name|
+          unless ActiveRecord::Base.connection.indexes(table_name).detect { |i| i.name == index_name }
             fail "The index `#{index_name}` was set to be dropped and recreated, but does not match any index in the schema"
           end
         end

--- a/spec/db_sanitiser/runner_spec.rb
+++ b/spec/db_sanitiser/runner_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe DbSanitiser::Runner do
     it "raises an error if a drop_and_create_index entry doesn't match the schema" do
       expect {
         described_class.new(fixture_file('drop_and_create_wrong_index.rb')).validate
-      }.to raise_error RuntimeError, a_string_including("The index `index_users_on_email` was set to be dropped and recreated, but does not match any index in the schema")
+      }.to raise_error RuntimeError, a_string_including("The index `index_users_on_edonkey` was set to be dropped and recreated, but does not match any index in the schema")
     end
   end
 

--- a/spec/support/fixtures/drop_and_create_index.rb
+++ b/spec/support/fixtures/drop_and_create_index.rb
@@ -1,5 +1,5 @@
 sanitise_table 'users' do
-  drop_and_create_index 'index_users_on_email', 'email'
+  drop_and_create_index 'index_users_on_email'
 
   sanitise 'email', string('barney.rubble@flintstones.com')
 

--- a/spec/support/fixtures/drop_and_create_wrong_index.rb
+++ b/spec/support/fixtures/drop_and_create_wrong_index.rb
@@ -1,5 +1,5 @@
 sanitise_table 'users' do
-  drop_and_create_index 'index_users_on_email', 'email', unique: true
+  drop_and_create_index 'index_users_on_edonkey'
 
   sanitise 'email', "CONCAT('user-', id, '@example.com')"
 


### PR DESCRIPTION
The first implementation of this method required us to re-specify the configuration of the index being dropped and recreated. This duplication with the schema makes the introduction of errors possible, requiring extra validation checks.

However, we can fetch the index config from ActiveRecord given only the table and index names, so this change does exactly that instead.