### PR TITLE
Fetch connection_config for Rails 6.1

### DIFF
--- a/lib/db_sanitiser/strategies/sanitise_strategy.rb
+++ b/lib/db_sanitiser/strategies/sanitise_strategy.rb
@@ -75,7 +75,11 @@ module DbSanitiser
       end
 
       def supports_skip_key_checks?
-        ActiveRecord::Base.connection_config[:adapter] == 'mysql2'
+        if ActiveRecord::Base.respond_to?(:connection_db_config)
+          ActiveRecord::Base.connection_db_config.adapter == 'mysql2'
+        else
+          ActiveRecord::Base.connection_config[:adapter] == 'mysql2'
+        end
       end
 
       def connection


### PR DESCRIPTION
In Rails 6.1.+ `connection_config` is deprecated:

```
ActiveSupport::DeprecationException:

  DEPRECATION WARNING: connection_config is deprecated and will be
removed from Rails 6.2 (Use connection_db_config instead) (called from
supports_skip_key_checks? at
/futurelearn/futurelearn/vendor/bundle/ruby/2.7.0/bundler/gems/db_sanitiser-c2a717e6a780/lib/db_sanitiser/strategies/sanitise_strategy.rb:78)
```

In order to make this gem work both with Rails 5.2 and Rails 6.1+,
let's add a check for which method is supported.

This will get rid of the deprecation warning but won't lock us into
upgrading this gem to activerecord 6.1 until we're running a stable
Rails 6.1 in production in the main futurelearn app.

[Trello](https://trello.com/c/NZiAH6ei/2411-upgrade-rails-to-6)