### PR TITLE
Update activerecord to 6.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,28 +2,27 @@ PATH
   remote: .
   specs:
     db_sanitiser (0.1.1)
-      activerecord
+      activerecord (~> 6.1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.6)
-      activesupport (= 5.2.6)
-    activerecord (5.2.6)
-      activemodel (= 5.2.6)
-      activesupport (= 5.2.6)
-      arel (>= 9.0)
-    activesupport (5.2.6)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    arel (9.0.0)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     coderay (1.1.2)
     concurrent-ruby (1.1.9)
     database_cleaner (1.6.2)
     diff-lcs (1.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.14.4)
@@ -45,9 +44,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    db_sanitiser (0.1.1)
+    db_sanitiser (0.1.2)
       activerecord (~> 6.1.4)
 
 GEM

--- a/db_sanitiser.gemspec
+++ b/db_sanitiser.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord"
+  spec.add_dependency "activerecord", "~> 6.1.4"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/db_sanitiser/strategies/sanitise_strategy.rb
+++ b/lib/db_sanitiser/strategies/sanitise_strategy.rb
@@ -75,11 +75,7 @@ module DbSanitiser
       end
 
       def supports_skip_key_checks?
-        if ActiveRecord::Base.respond_to?(:connection_db_config)
-          ActiveRecord::Base.connection_db_config.adapter == 'mysql2'
-        else
-          ActiveRecord::Base.connection_config[:adapter] == 'mysql2'
-        end
+        ActiveRecord::Base.connection_db_config.adapter == 'mysql2'
       end
 
       def connection

--- a/lib/db_sanitiser/version.rb
+++ b/lib/db_sanitiser/version.rb
@@ -1,3 +1,3 @@
 module DbSanitiser
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
We've previously [added some custom code][1] to make this gem work 
with both Rails 5.2 and Rails 6.1. 

We're now running on Rails 6.1.4 🎉 in the futurelearn app so we can get 
rid of this code.

Before we can do that, we'll have to update this gem to use activerecord
6.1.4.

Notice this ends up getting rid of the `arel` gem. That's because this
is now [bundled with activerecord][2]. 

It also causes multiple depedencies to be updated:
- activemodel
- activerecord
- i18n
- tzinfo

And finally we're also adding zeitwerk as a dependency.

[1]: #6
[2]: https://github.com/rails/arel

[Trello](https://trello.com/c/5LirfMLy/3275-clean-up-after-rails-614-migration)